### PR TITLE
Fix <Select> form input value

### DIFF
--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -310,8 +310,7 @@ export default class Select extends Component {
         return selectedMultiple;
       }
     } else if (option && typeof option === 'object') {
-      return (typeof option.label === 'string' ?
-        option.label : option.value || '');
+      return option.value || option.label || '';
     } else {
       return (undefined === option || null === option) ? '' : option;
     }


### PR DESCRIPTION
Currently, a &lt;Select&gt; used as a form input will submit the label of the selected option, instead of its value. This fix will make it submit the value, following HTML semantics.

#### What does this PR do?

Fixes an issue with &lt;Select&gt; components, when used as a form input. Currently, the form will have the value of the select option's label. Instead it should use the selected option's `value`.

#### Where should the reviewer start?

http://codepen.io/aandr/pen/jmOGYy

#### What testing has been done on this PR?

Tested locally.

#### How should this be manually tested?

Check out branch, try CodePen example: http://codepen.io/aandr/pen/jmOGYy 

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1305

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Yes. If somebody relied on a <Select> to submit it's option label instead of option value, this will now change.